### PR TITLE
feat: hprNummerSignerer if size of hpr > 9

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/DokArkivClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/DokArkivClient.kt
@@ -128,7 +128,7 @@ fun hprnummerMedRiktigLengdeOgFormat(
     if (hprnummerKunTallBehandler.length < 9) {
         return hprnummerKunTallBehandler.padStart(9, '0')
     }
-    if (hprnummerKunTallBehandler.length == 9) return hprNummerBehandler
+    if (hprnummerKunTallBehandler.length == 9) return hprnummerKunTallBehandler
     return hprnummerKunTallSignerer
 }
 

--- a/src/main/kotlin/no/nav/syfo/client/DokArkivClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/DokArkivClient.kt
@@ -31,7 +31,6 @@ import no.nav.syfo.model.Status
 import no.nav.syfo.model.ValidationResult
 import no.nav.syfo.model.Vedlegg
 import no.nav.syfo.objectMapper
-import no.nav.syfo.sikkerlogg
 import no.nav.syfo.util.LoggingMeta
 import no.nav.syfo.util.imageToPDF
 import no.nav.syfo.validation.validatePersonAndDNumber
@@ -46,7 +45,6 @@ class DokArkivClient(
         journalpostRequest: JournalpostRequest,
         loggingMeta: LoggingMeta,
     ): JournalpostResponse {
-        val requestBodyJson = journalpostRequestToJson(journalpostRequest)
         return try {
             log.info(
                 "Kall til dokarkiv Nav-Callid {}, {}",
@@ -68,13 +66,8 @@ class DokArkivClient(
                 httpResponse.status == HttpStatusCode.Created ||
                     httpResponse.status == HttpStatusCode.Conflict
             ) {
-                sikkerlogg.info("Info om journalpostRequest som gitt bra {}", kv("journalpostType", requestBodyJson))
                 httpResponse.call.response.body()
             } else {
-                sikkerlogg.error(
-                    "Info om journalpostRequesten {}",
-                    kv("journalpostType", requestBodyJson)
-                )
                 log.error(
                     "Mottok uventet statuskode fra dokarkiv: {}, Nav-Callid {}, {}, ",
                     httpResponse.status,
@@ -92,23 +85,6 @@ class DokArkivClient(
     }
 }
 
-fun journalpostRequestToJson(request: JournalpostRequest): String {
-    return """{
-        "avsenderMottaker": "${request.avsenderMottaker?.id}",
-        "behandlingstema": "${request.behandlingstema}",
-        "bruker": "${request.bruker?.id}",
-        "dokumenter": "${request.dokumenter.firstOrNull()?.tittel}",
-        "eksternReferanseId": "${request.eksternReferanseId}",
-        "journalfoerendeEnhet": "${request.journalfoerendeEnhet}",
-        "journalpostType": "${request.journalpostType}"
-        "kanal": "${request.kanal}"
-        "sak": "${request.sak?.sakstype}"
-        "tema": "${request.tema}"
-        "tittel": "${request.tittel}"
-    }"""
-        .trimIndent()
-}
-
 fun createJournalpostPayload(
     receivedSykmelding: ReceivedSykmelding,
     pdf: ByteArray,
@@ -117,31 +93,7 @@ fun createJournalpostPayload(
     loggingMeta: LoggingMeta,
 ) =
     JournalpostRequest(
-        avsenderMottaker =
-            if (receivedSykmelding.sykmelding.behandler.hpr != null) {
-                createAvsenderMottakerValidHpr(
-                        receivedSykmelding,
-                        receivedSykmelding.sykmelding.behandler.hpr!!.trim(),
-                    )
-                    .also {
-                        log.info(
-                            "Hpr nummer: {}, {}",
-                            receivedSykmelding.sykmelding.behandler.hpr!!.trim(),
-                            fields(loggingMeta),
-                        )
-                    }
-            } else {
-                when (validatePersonAndDNumber(receivedSykmelding.sykmelding.behandler.fnr)) {
-                    true ->
-                        createAvsenderMottakerValidFnr(receivedSykmelding).also {
-                            log.info("Using fnr as avsenderMottaker")
-                        }
-                    else ->
-                        createAvsenderMottakerNotValidFnr(receivedSykmelding).also {
-                            log.info("Using only name as avsenderMottaker")
-                        }
-                }
-            },
+        avsenderMottaker = setAvsenderMottaker(receivedSykmelding, loggingMeta),
         bruker =
             Bruker(
                 id = receivedSykmelding.personNrPasient,
@@ -167,12 +119,48 @@ fun createJournalpostPayload(
         tittel = createTittleJournalpost(validationResult, receivedSykmelding),
     )
 
-fun hprnummerMedRiktigLengdeOgFormat(hprnummer: String): String {
-    val hprnummerKunTall = hprnummer.filter { it.isDigit() }
-    if (hprnummerKunTall.length < 9) {
-        return hprnummerKunTall.padStart(9, '0')
+fun hprnummerMedRiktigLengdeOgFormat(
+    hprNummerBehandler: String,
+    hprNummerSignerer: String
+): String {
+    val hprnummerKunTallBehandler = hprNummerBehandler.filter { it.isDigit() }
+    val hprnummerKunTallSignerer = hprNummerSignerer.filter { it.isDigit() }
+    if (hprnummerKunTallBehandler.length < 9) {
+        return hprnummerKunTallBehandler.padStart(9, '0')
     }
-    return hprnummerKunTall
+    if (hprnummerKunTallBehandler.length == 9) return hprNummerBehandler
+    return hprnummerKunTallSignerer
+}
+
+private fun setAvsenderMottaker(
+    receivedSykmelding: ReceivedSykmelding,
+    loggingMeta: LoggingMeta
+): AvsenderMottaker {
+    val hprNummerSignerer = receivedSykmelding.legeHprNr
+    val hprnummerBehandler = receivedSykmelding.sykmelding.behandler.hpr
+    if (hprnummerBehandler != null && hprNummerSignerer != null) {
+        return createAvsenderMottakerValidHpr(
+                receivedSykmelding,
+                hprnummerBehandler,
+                hprNummerSignerer
+            )
+            .also {
+                log.info(
+                    "Hpr numre: {}, {} {}",
+                    kv("HPR nummer behandler", hprnummerBehandler),
+                    kv("HPR nummer signerer", hprNummerSignerer),
+                    fields(loggingMeta),
+                )
+            }
+    }
+    if (validatePersonAndDNumber(receivedSykmelding.sykmelding.behandler.fnr)) {
+        return createAvsenderMottakerValidFnr(receivedSykmelding).also {
+            log.info("Using fnr as avsenderMottaker")
+        }
+    }
+    return createAvsenderMottakerNotValidFnr(receivedSykmelding).also {
+        log.info("Using only name as avsenderMottaker")
+    }
 }
 
 fun leggtilDokument(
@@ -276,10 +264,11 @@ fun createAvsenderMottakerValidFnr(receivedSykmelding: ReceivedSykmelding): Avse
 
 fun createAvsenderMottakerValidHpr(
     receivedSykmelding: ReceivedSykmelding,
-    hprnummer: String
+    hprnummerBehandler: String,
+    hprNummerSignerer: String,
 ): AvsenderMottaker =
     AvsenderMottaker(
-        id = hprnummerMedRiktigLengdeOgFormat(hprnummer),
+        id = hprnummerMedRiktigLengdeOgFormat(hprnummerBehandler, hprNummerSignerer),
         idType = "HPRNR",
         land = "Norge",
         navn = receivedSykmelding.sykmelding.behandler.formatName(),
@@ -297,7 +286,7 @@ fun createTittleJournalpost(
 ): String {
     return if (validationResult.status == Status.INVALID) {
         "Avvist sykmelding ${getFomTomTekst(receivedSykmelding)}"
-    } else if  (receivedSykmelding.ugyldigTilbakedatering()) {
+    } else if (receivedSykmelding.ugyldigTilbakedatering()) {
         "Avslått sykmelding ${getFomTomTekst(receivedSykmelding)}"
     } else if (receivedSykmelding.delvisGodkjent()) {
         "Delvis godkjent sykmelding ${getFomTomTekst(receivedSykmelding)}"
@@ -311,11 +300,11 @@ fun createTittleJournalpost(
 }
 
 fun ReceivedSykmelding.ugyldigTilbakedatering(): Boolean {
-    return merknader != null && merknader!!.any {it.type == "UGYLDIG_TILBAKEDATERING"}
+    return merknader != null && merknader!!.any { it.type == "UGYLDIG_TILBAKEDATERING" }
 }
 
 fun ReceivedSykmelding.delvisGodkjent(): Boolean {
-    return merknader != null && merknader!!.any {it.type == "DELVIS_GODKJENT"}
+    return merknader != null && merknader!!.any { it.type == "DELVIS_GODKJENT" }
 }
 
 fun ReceivedSykmelding.erUtenlandskSykmelding(): Boolean {

--- a/src/test/kotlin/no/nav/syfo/client/DokArkivClientKtTest.kt
+++ b/src/test/kotlin/no/nav/syfo/client/DokArkivClientKtTest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.syfo.model.VedleggMessage
 import no.nav.syfo.objectMapper
 import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 internal class DokArkivClientKtTest {
@@ -18,7 +19,7 @@ internal class DokArkivClientKtTest {
 
         val oppdatertVedlegg = vedleggToPDF(gosysVedlegg)
 
-        Assertions.assertEquals(gosysVedlegg, oppdatertVedlegg)
+        assertEquals(gosysVedlegg, oppdatertVedlegg)
     }
 
     @Test
@@ -32,28 +33,37 @@ internal class DokArkivClientKtTest {
         val oppdatertVedlegg = vedleggToPDF(gosysVedlegg)
 
         Assertions.assertNotEquals(gosysVedlegg, oppdatertVedlegg)
-        Assertions.assertEquals("application/pdf", oppdatertVedlegg.contentType)
-        Assertions.assertEquals(vedleggMessage.vedlegg.description, oppdatertVedlegg.description)
+        assertEquals("application/pdf", oppdatertVedlegg.contentType)
+        assertEquals(vedleggMessage.vedlegg.description, oppdatertVedlegg.description)
     }
 
     @Test
     internal fun `Skal legge paa padding dersom hpr er under 9 siffer`() {
-        val hprnummmer = hprnummerMedRiktigLengdeOgFormat("02345678 ".trim())
-
-        Assertions.assertEquals("002345678", hprnummmer)
+        val hprnummmer = hprnummerMedRiktigLengdeOgFormat("02345678 ".trim(), "02345678")
+        assertEquals("002345678", hprnummmer)
     }
 
     @Test
     internal fun `Skal fjerne - fra hprnummer`() {
-        val hprnummmer = hprnummerMedRiktigLengdeOgFormat("-02345678".trim())
-
-        Assertions.assertEquals("002345678", hprnummmer)
+        val hprnummmer = hprnummerMedRiktigLengdeOgFormat("-02345678".trim(), "02345678")
+        assertEquals("002345678", hprnummmer)
     }
 
     @Test
     internal fun `Skal fjerne bokstaver fra hprnummer`() {
-        val hprnummmer = hprnummerMedRiktigLengdeOgFormat("0A234B5678".trim())
+        val hprnummmer = hprnummerMedRiktigLengdeOgFormat("0A234B5678".trim(), "02345678")
+        assertEquals("002345678", hprnummmer)
+    }
 
-        Assertions.assertEquals("002345678", hprnummmer)
+    @Test
+    internal fun `Skal bruke signatur hprnummer dersom hprBehandler er lengre enn 9 siffer`() {
+        val hprnummmer = hprnummerMedRiktigLengdeOgFormat("11111111111", "02345678")
+        assertEquals("02345678", hprnummmer)
+    }
+
+    @Test
+    internal fun `Skal bruke behandler hprnummer dersom hprBehandler er lik 9 siffer`() {
+        val hprnummmer = hprnummerMedRiktigLengdeOgFormat("111111111", "02345678")
+        assertEquals("111111111", hprnummmer)
     }
 }


### PR DESCRIPTION
vi hadde en bug hvor det var en behandler uten gyldig hpr som hadde skrevet sykmeldingen. Dokarkiv godtar kun hpr size mellom 7 og 9 derfor bruker vi hpr signerer i disse tilfellene.